### PR TITLE
added wildcard prefix (*) support to PackMule specific item rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/Classes/Helpers.lua
+++ b/Classes/Helpers.lua
@@ -386,6 +386,15 @@ function GL:strStartsWith(str, startStr)
    return string.sub(str, 1, string.len(startStr)) == startStr;
 end
 
+--- Check whether the provided string ends with a given substring
+---
+---@param str string
+---@param startStr string
+---@return boolean
+function GL:strEndsWith(str, endStr)
+	return string.sub(str,-(string.len(endStr))) == endStr;
+end
+
 --- Print large quantities of text to a multiline editbox
 --- Very useful for debugging purposes, should not be used for anything else
 ---

--- a/Classes/PackMule.lua
+++ b/Classes/PackMule.lua
@@ -236,7 +236,7 @@ function PackMule:lootReady()
                         end
                     elseif (item and (
                         (ruleConcernsItemID and ruleItemID == itemID) -- Item is an ID and the IDs match
-                        or (type(item) == "string" and string.lower(item) == string.lower(itemName)) -- Item is a name and the names match
+                        or (type(item) == "string" and PackMule:lootItemMatchesSpecificRule(itemName,item)) -- item (rule) is a name and it matches loot name
                     )) then
                         -- We found an item-specific rule, we can stop checking now
                         RuleThatApplies = Rule;
@@ -273,6 +273,21 @@ function PackMule:lootReady()
     end
 
     self.processing = false;
+end
+
+---See if loot item name matches a specific rule, supporting wildcard prefix
+---
+---@return boolean
+function PackMule:lootItemMatchesSpecificRule(lootItemName,specificRuleName)
+	if (string.lower(lootItemName) == string.lower(specificRuleName)) then -- loot item name is exact match
+		return true;
+	elseif (GL:strStartsWith(specificRuleName,"*")) then --specific rule starts with wildcard
+		local searchName = string.sub(specificRuleName,2,-1); --strip wildcard
+		if (GL:strEndsWith(lootItemName,searchName)) then --loot item name matches wildcard search
+			return true;
+		end
+	end
+	return false;
 end
 
 --- Empty the ruleset


### PR DESCRIPTION
Ahoy Z - I couldn't see a reason to bloat this up with suffix wildcard support, but the Era use case is set a couple specific item rules to override the quest item auto-ignores, for example in ZG/AQ20 we can set up specific rules for *Coin, *Bijou, *Idol, and *Scarab to send those to a pack mule.  Short circuited with the exact string comparison first - haven't noticed any performance issues testing in-game.

Testing:  in Stockades I set up PM rule > 0-Poor to IGNORE, then set specific item for *Cloth to SELF and verified all the cloth was PM'd to me.