### PR TITLE
Added round robin functionality and 'RR' placeholder in PackMule

### DIFF
--- a/Classes/PackMule.lua
+++ b/Classes/PackMule.lua
@@ -511,7 +511,6 @@ function PackMule:getTargetForItem(itemLinkOrId, callback)
         end
 
         local ruleTarget = strtrim(RuleThatApplies.target);
-        
         local Targets = {};
 
         local RuleTargets = GL:strSplit(ruleTarget, " ");
@@ -545,15 +544,15 @@ function PackMule:getTargetForItem(itemLinkOrId, callback)
                         return callback(false); -- No point continuing, don't want the item to end up in the wrong hands!
                     end
 
-				-- RR placeholder represents the next player in a round robin scheme for this rule
-				elseif (ruleTarget == "RR") then
-					ruleTarget = self:roundRobinNextPlayerForRule(RuleThatApplies);
+                -- RR placeholder represents the next player in a round robin scheme for this rule
+                elseif (ruleTarget == "RR") then
+                    ruleTarget = self:roundRobinNextPlayerForRule(RuleThatApplies);
 
                 -- Check whether we need to give the item to a random player
                 elseif (ruleTarget == "RANDOM") then
                     for _, Player in pairs(GL.User:groupMembers()) do
-						if (Player.online) then 
-							tinsert(Targets, string.lower(Player.name));
+                        if (Player.online) then 
+                            tinsert(Targets, string.lower(Player.name));
                         end
                     end
 
@@ -855,42 +854,42 @@ end
 ---@param ruleItem string
 ---@return string
 function PackMule:roundRobinNextPlayerForRule(rule)
-	GL:debug("PackMule:roundRobinNextPlayerForRule");
-	
-	local ruleId = "";
-	
-	if (not GL.empty(rule.item)) then
-		ruleId = rule.item;
-	else 
-		ruleId = rule.quality;
+    GL:debug("PackMule:roundRobinNextPlayerForRule");
+
+    local ruleId = "";
+
+    if (not GL.empty(rule.item)) then
+        ruleId = rule.item;
+    else
+        ruleId = rule.quality;
 	end
-	
-	if (not RoundRobinItems[ruleId]) then
-		-- first time we've seen this item
-		RoundRobinItems[ruleId] = {};
-	end
-	
-	local targetPlayer = false;
-	
-	for _, Player in pairs(GL.User:groupMembers()) do
-		local playerName = string.lower(Player.name);
-		if (Player.online and not RoundRobinItems[ruleId][playerName]) then
-			-- this player hasn't received one of these items yet
-			RoundRobinItems[ruleId][playerName] = 1;
-			targetPlayer = playerName;
-			break;		
-		end
+
+    if (not RoundRobinItems[ruleId]) then
+        -- first time we've seen this item
+        RoundRobinItems[ruleId] = {};
     end
-    
+
+    local targetPlayer = false;
+
+    for _, Player in pairs(GL.User:groupMembers()) do
+        local playerName = string.lower(Player.name);
+        if (Player.online and not RoundRobinItems[ruleId][playerName]) then
+            -- this player hasn't received one of these items yet
+            RoundRobinItems[ruleId][playerName] = 1;
+            targetPlayer = playerName;
+            break;
+        end
+    end
+
     if (not targetPlayer) then
-		-- everyone has received one of these, start over
-		GL:debug("PackMule:roundRobinNextPlayerForRule - starting over");
-		wipe(RoundRobinItems[ruleId]);
-		return self:roundRobinNextPlayerForRule(rule);
+        -- everyone has received one of these, start over
+        GL:debug("PackMule:roundRobinNextPlayerForRule - starting over");
+        wipe(RoundRobinItems[ruleId]);
+        return self:roundRobinNextPlayerForRule(rule);
     end
-    
+
     return targetPlayer;
-	
+
 end
 
 --- Assign a item to a player


### PR DESCRIPTION
When an item which matches a quality or specific item rule should be distributed in a round robin fashion (instead of RANDOM), the user can specify the RR placeholder instead.  A table is kept and pruned to keep track of players who have received an item that matches the rule.   