### PR TITLE
Add hr player name on tooltip

### DIFF
--- a/Classes/SoftRes.lua
+++ b/Classes/SoftRes.lua
@@ -489,6 +489,14 @@ function SoftRes:getHardReservedByLink(itemLink)
     return self.MaterializedData.HardReserveDetailsByID[tostring(itemID)];
 end
 
+--- Check whether a given item id is hard-reserved
+---
+---@param itemID number|string
+---@return boolean
+function SoftRes:IDIsHardReserved(itemID)
+    return self.MaterializedData.HardReserveDetailsByID[tostring(itemID)] ~= nil;
+end
+
 --- Check whether a given itemlink is hard-reserved
 ---
 ---@param itemLink string


### PR DESCRIPTION
Simple add the designated player for the HR (if provided on softres.it) . 

When class unknown (ie player is not register on softres, or with a different name):
![image](https://user-images.githubusercontent.com/118932617/203657924-57336ca6-0cb2-431b-ab03-75f31fdec483.png)

When class known:
![image](https://user-images.githubusercontent.com/118932617/203658134-cac243f3-dcde-4452-8b48-336a0d3d9e46.png)
