### PR TITLE
Fix clearplusones command

### DIFF
--- a/Classes/Commands.lua
+++ b/Classes/Commands.lua
@@ -137,7 +137,7 @@ GL.Commands = GL.Commands or {
         setdisenchanter = function (...) GL.PackMule:setDisenchanter(...); end,
 
         -- Clear all plus ones
-        clearplusones = function() GL.PlusOnes:clear(); end,
+        clearplusones = function() GL.PlusOnes:clearPlusOnes(); end,
 
         -- Export the current raid roster to csv
         raidcsv = function ()


### PR DESCRIPTION
Updates the clearplusones command to call the renamed `PlusOnes:clearPlusOnes` method.

Resolves #81.