### PR TITLE
Allow CTRL_CLICK on countdown bar to preview item in dressing room

### DIFF
--- a/Classes/RollerUI.lua
+++ b/Classes/RollerUI.lua
@@ -201,9 +201,19 @@ function RollerUI:drawCountdownBar(time, itemLink, itemIcon, note, userCanUseIte
     end);
 
     -- Close the roll window on rightclick
+    -- Preview the item in the dressing room on ctrl_click
     TimerBar:SetScript("OnMouseDown", function(_, button)
         if (button == "RightButton") then
             self:hide();
+        end
+
+        local combo = GL.Events.getClickCombination(button);
+        if (button == "LeftButton" and combo == "CTRL_CLICK") then
+          -- `Show` must be called before `TryOn`, or else the item will
+          -- not appear the first time.
+          DressUpFrame:Show();
+          DressUpFrame.DressUpModel:SetUnit("player");
+          DressUpFrame.DressUpModel:TryOn(itemLink);
         end
     end)
 


### PR DESCRIPTION
I love Gargul! It's made my life both as loot master and as a raider so much simpler/fun :) 

One thing I have noticed, however, is that I always find myself ctrl-clicking the items in the countdown bar, only to find that it doesn't trigger the dressing room to preview said item. I implemented that here in the simplest way I could work out, let me know if this is a change you would accept.

`DressUpFrame` doesn't come auto-populated with the background texture for your race, and I wasn't able to figure out how to populate that texture manually, so a blank background will show up in the dressing room frame if you haven't previously previewed another item. This isn't ideal, obviously, but it's something I can live with. If you want me to keep digging lmk. 

![ezgif com-optimize](https://user-images.githubusercontent.com/35509264/234758395-83329d5a-b56b-4b35-9d31-b2ce3e99cb42.gif)
