### PR TITLE
Implement simple anti-snipe

### DIFF
--- a/Classes/GDKP/Auction.lua
+++ b/Classes/GDKP/Auction.lua
@@ -1999,7 +1999,7 @@ function Auction:processBid(message, bidder)
             local secondsLeft = math.floor(GL.Ace:TimeLeft(self.timerId) - GL.Settings:get("GDKP.auctionEndLeeway", 2));
             if (secondsLeft <= self.Current.antiSnipe) then
                 if(Settings:get("GDKP.simpleAntiSnipe")) then
-                    self:announceReschedule(newDuration);
+                    self:announceReschedule(self.Current.antiSnipe);
                 else
                     self:announceExtension(self.Current.antiSnipe);
                 end

--- a/Classes/GDKP/Auction.lua
+++ b/Classes/GDKP/Auction.lua
@@ -1242,7 +1242,7 @@ function Auction:announceStop(forceStop)
         and GetTime() - self.lastBidReceivedAt <= self.Current.antiSnipe
         and not self.waitingForReschedule
     ) then
-        self:announceExtension(self.Current.antiSnipe);
+        self:announceReschedule(self.Current.antiSnipe);
         return;
     end
 
@@ -1998,7 +1998,11 @@ function Auction:processBid(message, bidder)
             self.lastBidReceivedAt = GetTime();
             local secondsLeft = math.floor(GL.Ace:TimeLeft(self.timerId) - GL.Settings:get("GDKP.auctionEndLeeway", 2));
             if (secondsLeft <= self.Current.antiSnipe) then
-                self:announceExtension(self.Current.antiSnipe);
+                if(Settings:get("GDKP.simpleAntiSnipe")) then
+                    self:announceReschedule(newDuration);
+                else
+                    self:announceExtension(self.Current.antiSnipe);
+                end
             end
         end
     end

--- a/Data/DefaultSettings.lua
+++ b/Data/DefaultSettings.lua
@@ -144,6 +144,7 @@ GL.Data.DefaultSettings = {
         auctionEndLeeway = 2,
         autoAwardViaAuctioneer = true,
         antiSnipe = 10,
+        simpleAntiSnipe = false,
         bidderScale = 1,
         bidderQueueHideUnusable = false,
         defaultMinimumBid = 500,

--- a/Data/Localizations/de.lua
+++ b/Data/Localizations/de.lua
@@ -15,6 +15,13 @@ L.ANTISNIPE_EXPLANATION = {
     "You can leave this empty or set to 0 to disable Anti Snipe completely",
     " ",
 };
+L.SIMPLE_ANTISNIPE = "Simple Anti Snipe";
+L.SIMPLE_ANTISNIPE_EXPLANATION = {
+    " ",
+    "Simple Anti Snipe means with Anti Snipe set to 10,",
+    "any bid at less than 10 seconds resets the time remaining to 10 seconds",
+    " ",
+};
 L.ADD_DROPS_TO_QUEUE = "Add dropped loot to queue";
 L.AUCTIONS = "Auktionen";
 L.AUTO_AWARD = "Auto award";

--- a/Data/Localizations/en.lua
+++ b/Data/Localizations/en.lua
@@ -15,6 +15,13 @@ L.ANTISNIPE_EXPLANATION = {
     "You can leave this empty or set to 0 to disable Anti Snipe completely",
     " ",
 };
+L.SIMPLE_ANTISNIPE = "Simple Anti Snipe";
+L.SIMPLE_ANTISNIPE_EXPLANATION = {
+    " ",
+    "Simple Anti Snipe means with Anti Snipe set to 10,",
+    "any bid at less than 10 seconds resets the time remaining to 10 seconds",
+    " ",
+};
 L.ADD_DROPS_TO_QUEUE = "Add dropped loot to queue";
 L.ALL_CUTS_MAILED = "All cuts were mailed!";
 L.AUCTIONEER = "Auctioneer";

--- a/Interface/Settings/GDKP.lua
+++ b/Interface/Settings/GDKP.lua
@@ -145,6 +145,11 @@ function GDKP:draw(Parent)
             setting = "GDKP.invalidBidsTriggerAntiSnipe",
         },
         {
+            label = "Simple anti-snipe",
+            description = "Bids within the anti-snipe window will reset the timer to the anti-snipe time",
+            setting = "GDKP.simpleAntiSnipe",
+        },
+        {
             label = "Auto award items",
             description = "Auto award an item to the highest bidder when the timer runs out (clicking \"Stop\" during an auction will not trigger this)",
             setting = "GDKP.autoAwardViaAuctioneer",


### PR DESCRIPTION
Implements simpler anti-snipe logic.  Any bid coming in within the anti-snipe window reschedules the auction to the anti-snipe time.

Uses `announceReschedule` instead of `announceExtension`.  This means that if the anti-snipe is set to 15 seconds, any bid with less than 15 seconds on the timer resets it to 15 seconds.

I put this behind a setting, but I think potentially there is no reason to have the setting and to just always use `announceReschedule`.  If so, this PR could be much more minimal.