### PR TITLE
Simple antisnipe [minimal option]

### DIFF
--- a/Classes/GDKP/Auction.lua
+++ b/Classes/GDKP/Auction.lua
@@ -1242,7 +1242,7 @@ function Auction:announceStop(forceStop)
         and GetTime() - self.lastBidReceivedAt <= self.Current.antiSnipe
         and not self.waitingForReschedule
     ) then
-        self:announceExtension(self.Current.antiSnipe);
+        self:announceReschedule(self.Current.antiSnipe);
         return;
     end
 
@@ -1998,7 +1998,7 @@ function Auction:processBid(message, bidder)
             self.lastBidReceivedAt = GetTime();
             local secondsLeft = math.floor(GL.Ace:TimeLeft(self.timerId) - GL.Settings:get("GDKP.auctionEndLeeway", 2));
             if (secondsLeft <= self.Current.antiSnipe) then
-                self:announceExtension(self.Current.antiSnipe);
+                self:announceReschedule(self.Current.antiSnipe);
             end
         end
     end

--- a/Classes/GDKP/Auction.lua
+++ b/Classes/GDKP/Auction.lua
@@ -1997,7 +1997,7 @@ function Auction:processBid(message, bidder)
         )) then
             self.lastBidReceivedAt = GetTime();
             local secondsLeft = math.floor(GL.Ace:TimeLeft(self.timerId) - GL.Settings:get("GDKP.auctionEndLeeway", 2));
-            if (secondsLeft <= self.Current.antiSnipe) then
+            if (secondsLeft < self.Current.antiSnipe) then
                 self:announceReschedule(self.Current.antiSnipe);
             end
         end

--- a/Data/Localizations/de.lua
+++ b/Data/Localizations/de.lua
@@ -9,8 +9,8 @@ L.ALL_SETTINGS = "Alle Einstellungen";
 L.ANTISNIPE = "Anti Snipe";
 L.ANTISNIPE_EXPLANATION = {
     " ",
-    "An Anti Snipe value of 10 means that 10 seconds will be added",
-    "to the auction if someone bids within the last 10 seconds",
+    "An Anti Snipe value of 10 means that any bid at less than 10 seconds left",
+    "resets the time remaining to 10 seconds",
     " ",
     "You can leave this empty or set to 0 to disable Anti Snipe completely",
     " ",

--- a/Data/Localizations/de.lua
+++ b/Data/Localizations/de.lua
@@ -9,10 +9,11 @@ L.ALL_SETTINGS = "Alle Einstellungen";
 L.ANTISNIPE = "Anti Snipe";
 L.ANTISNIPE_EXPLANATION = {
     " ",
-    "An Anti Snipe value of 10 means that any bid at less than 10 seconds left",
-    "resets the time remaining to 10 seconds",
+    "An Anti Snipe value of 10 means any bids with less than 10 seconds left",
+    "resets the time remaining back to 10 seconds",
     " ",
     "You can leave this empty or set to 0 to disable Anti Snipe completely",
+    "Anti Snipe values less than 5 are not supported",
     " ",
 };
 L.ADD_DROPS_TO_QUEUE = "Add dropped loot to queue";

--- a/Data/Localizations/en.lua
+++ b/Data/Localizations/en.lua
@@ -9,8 +9,8 @@ L.ALL_SETTINGS = "All Settings";
 L.ANTISNIPE = "Anti Snipe";
 L.ANTISNIPE_EXPLANATION = {
     " ",
-    "An Anti Snipe value of 10 means that 10 seconds will be added",
-    "to the auction if someone bids within the last 10 seconds",
+    "An Anti Snipe value of 10 means that any bid at less than 10 seconds left",
+    "resets the time remaining to 10 seconds",
     " ",
     "You can leave this empty or set to 0 to disable Anti Snipe completely",
     " ",

--- a/Data/Localizations/en.lua
+++ b/Data/Localizations/en.lua
@@ -9,10 +9,11 @@ L.ALL_SETTINGS = "All Settings";
 L.ANTISNIPE = "Anti Snipe";
 L.ANTISNIPE_EXPLANATION = {
     " ",
-    "An Anti Snipe value of 10 means that any bid at less than 10 seconds left",
-    "resets the time remaining to 10 seconds",
+    "An Anti Snipe value of 10 means any bids with less than 10 seconds left",
+    "resets the time remaining back to 10 seconds",
     " ",
     "You can leave this empty or set to 0 to disable Anti Snipe completely",
+    "Anti Snipe values less than 5 are not supported",
     " ",
 };
 L.ADD_DROPS_TO_QUEUE = "Add dropped loot to queue";


### PR DESCRIPTION
Implements simpler anti-snipe logic. Any bid coming in within the anti-snipe window reschedules the auction to the anti-snipe time.

Uses announceReschedule instead of announceExtension. This means that if the anti-snipe is set to 15 seconds, any bid with less than 15 seconds on the timer resets it to 15 seconds.