### PR TITLE
Feature/dft prio display

### DIFF
--- a/Classes/DroppedLoot.lua
+++ b/Classes/DroppedLoot.lua
@@ -404,10 +404,14 @@ function DroppedLoot:announce(Modifiers)
             if (itemIsOnSomeonesPriolist
                 and GL.Settings:get("TMB.includePrioListInfoInLootAnnouncement")
             ) then
-                -- Sort the PrioListEntries based on prio (lowest to highest)
+                -- Sort the PrioListEntries based on prio
                 table.sort(ActivePrioListDetails, function (a, b)
                     if (a.order and b.order) then
-                        return a.order < b.order;
+                        if (GL.TMB:wasImportedFromDFT()) then
+                            return a.order > b.order;
+                        else
+                            return a.order < b.order;
+                        end
                     end
 
                     return false;

--- a/Classes/RollOff.lua
+++ b/Classes/RollOff.lua
@@ -179,10 +179,14 @@ function RollOff:postStartMessage(itemLink, time, note)
         if (not GL:empty(PrioListEntries)
             and GL.Settings:get("TMB.announcePriolistInfoWhenRolling")
         ) then
-            -- Sort the PrioListEntries based on prio (lowest to highest)
+            -- Sort the PrioListEntries based on prio
             table.sort(PrioListEntries, function (a, b)
                 if (a.prio and b.prio) then
-                    return a.prio < b.prio;
+                    if (GL.TMB:wasImportedFromDFT()) then
+                        return a.prio > b.prio;
+                    else
+                        return a.prio < b.prio;
+                    end
                 end
 
                 return false;
@@ -194,7 +198,7 @@ function RollOff:postStartMessage(itemLink, time, note)
                     tinsert(EligiblePlayers, Entry);
                 else
                     -- This players prio is worse than the number one, break!
-                    if (Entry.prio > EligiblePlayers[1].prio) then
+                    if (Entry.prio ~= EligiblePlayers[1].prio) then
                         break;
                     end
 

--- a/Classes/TMB.lua
+++ b/Classes/TMB.lua
@@ -418,10 +418,14 @@ function TMB:tooltipLines(itemLink)
         local source = GL.TMB:source();
         tinsert(Lines, string.format("\n|cFFff7a0a%s|r", source .. " Prio List"));
 
-        -- Sort the PrioListEntries based on prio (lowest to highest)
+        -- Sort the PrioListEntries based on prio
         table.sort(PrioListEntries, function (a, b)
             if (a[1] and b[1]) then
-                return a[1] < b[1];
+                if (TMB:wasImportedFromDFT()) then
+                    return a[1] > b[1];
+                else
+                    return a[1] < b[1];
+                end
             end
 
             return false;
@@ -933,7 +937,7 @@ function TMB:DFTFormatToTMB(data)
                 priorityIndex = priorityIndex + 1;
             end
 
-            TMBData.wishlists[itemID][key] = string.format("%s||%s||1||1", string.lower(Priority.player), priorityIndex);
+            TMBData.wishlists[itemID][key] = string.format("%s||%s||1||1", string.lower(Priority.player), Priority.priority);
         end
     end
 

--- a/Classes/TMB.lua
+++ b/Classes/TMB.lua
@@ -919,9 +919,6 @@ function TMB:DFTFormatToTMB(data)
 
     -- Rewrite the priorities to match DFTs behavior
     for itemID, Priorities in pairs(TMBData.wishlists) do
-        local lastPriority = 99999;
-        local priorityIndex = 0;
-
         -- Sort the priorities (highest to lowest)
         table.sort(Priorities, function (a, b)
             if (a.priority and b.priority) then
@@ -932,11 +929,6 @@ function TMB:DFTFormatToTMB(data)
         end);
 
         for key, Priority in pairs(Priorities) do
-            if (Priority.priority < lastPriority) then
-                lastPriority = Priority.priority;
-                priorityIndex = priorityIndex + 1;
-            end
-
             TMBData.wishlists[itemID][key] = string.format("%s||%s||1||1", string.lower(Priority.player), Priority.priority);
         end
     end

--- a/Interface/Award/Award.lua
+++ b/Interface/Award/Award.lua
@@ -558,7 +558,11 @@ function Award:topPrioForItem(itemID)
         -- Sort the PrioListEntries based on prio (lowest to highest)
         table.sort(PrioListEntries, function (a, b)
             if (a.prio and b.prio) then
-                return a.prio < b.prio;
+                if (GL.TMB:wasImportedFromDFT()) then
+                    return a.prio > b.prio;
+                else
+                    return a.prio < b.prio;
+                end
             end
 
             return false;


### PR DESCRIPTION
DFT uses "Bigger numbers win" instead of TMB's "smaller numbers win".
This change updates the sorting order and rankings when using a DFT import.