### PR TITLE
add forceRoll feature, that allows you to auto-roll on items according to PackMule rules

### DIFF
--- a/Classes/PackMule.lua
+++ b/Classes/PackMule.lua
@@ -51,7 +51,7 @@ function PackMule:_init()
 
     self.Rules = Settings:get("PackMule.Rules");
 
-    -- Await is needed to prevent GetInstanceInfo() from returning wrong difficulty randomly
+    -- Await is needed to prevent GetInstanceInfo() from returning wrong difficulty sometimes when using RDF
     GL.Events:register("PackMuleZoneChangeListener", "ZONE_CHANGED_NEW_AREA", function ()
         GL:after(2, "PackMuleZoneChangeListenerWait", function ()
             self:zoneChanged();

--- a/Classes/PackMule.lua
+++ b/Classes/PackMule.lua
@@ -504,9 +504,10 @@ function PackMule:getTargetForItem(itemLinkOrId, callback)
                         return true;
                     end
 
-                    -- When in group loot never auto need anything that's BoP unless you have lead or assist!
+                    -- When in group loot never auto need anything that's BoP unless you have lead or assist or forceRoll enabled!
                     if (not GL.User.isMasterLooter
                         and not GL.User.hasAssist
+                        and not GL.Settings:get("PackMule.forceRoll")
                         and strfind(target, "NEED")
                     ) then
                         return false;

--- a/Classes/PackMule.lua
+++ b/Classes/PackMule.lua
@@ -51,6 +51,7 @@ function PackMule:_init()
 
     self.Rules = Settings:get("PackMule.Rules");
 
+    -- Await is needed to prevent GetInstanceInfo() from returning wrong difficulty randomly
     GL.Events:register("PackMuleZoneChangeListener", "ZONE_CHANGED_NEW_AREA", function ()
         GL:after(2, "PackMuleZoneChangeListenerWait", function ()
             self:zoneChanged();

--- a/Classes/PackMule.lua
+++ b/Classes/PackMule.lua
@@ -52,7 +52,9 @@ function PackMule:_init()
     self.Rules = Settings:get("PackMule.Rules");
 
     GL.Events:register("PackMuleZoneChangeListener", "ZONE_CHANGED_NEW_AREA", function ()
-        self:zoneChanged();
+        GL:after(2, "PackMuleZoneChangeListenerWait", function ()
+            self:zoneChanged();
+        end);
     end);
 
     GL.Events:register("PackMuleUserLeftGroupListener", "GL.USER_LEFT_GROUP", function ()

--- a/Data/DefaultSettings.lua
+++ b/Data/DefaultSettings.lua
@@ -99,6 +99,7 @@ GL.Data.DefaultSettings = {
         autoConfirmSolo = false,
         autoConfirmGroup = false,
         autoDisableForGroupLoot = true,
+        forceRoll = false,
         enabledForGroupLoot = false,
         enabledForMasterLoot = false,
         lootGold = true,

--- a/Data/DefaultSettings.lua
+++ b/Data/DefaultSettings.lua
@@ -95,8 +95,8 @@ GL.Data.DefaultSettings = {
         }
     },
     PackMule = {
-    announceDisenchantedItems = true,
-    autoConfirmSolo = false,
+        announceDisenchantedItems = true,
+        autoConfirmSolo = false,
         autoConfirmGroup = false,
         autoDisableForGroupLoot = true,
         forceRoll = false,

--- a/Data/DefaultSettings.lua
+++ b/Data/DefaultSettings.lua
@@ -95,8 +95,8 @@ GL.Data.DefaultSettings = {
         }
     },
     PackMule = {
-        announceDisenchantedItems = true,
-        autoConfirmSolo = false,
+    announceDisenchantedItems = true,
+    autoConfirmSolo = false,
         autoConfirmGroup = false,
         autoDisableForGroupLoot = true,
         forceRoll = false,

--- a/Interface/Settings/PackMule.lua
+++ b/Interface/Settings/PackMule.lua
@@ -26,7 +26,7 @@ function PackMule:draw(Parent)
         GL.Settings:draw("PackMuleIgnores");
     end);
     Parent:AddChild(IgnoredItems);
-
+    
     Overview:drawSpacer(Parent, nil, 10);
 
     local Checkboxes = {
@@ -43,6 +43,7 @@ function PackMule:draw(Parent)
             label = "Force Group Loot",
             description = "Roll on items when not leader or loot assist (useful for RDF spam)",
             setting = "PackMule.forceRoll",
+        },
         {
             label = "Disable for Group Loot when leaving group",
             setting = "PackMule.autoDisableForGroupLoot",

--- a/Interface/Settings/PackMule.lua
+++ b/Interface/Settings/PackMule.lua
@@ -26,7 +26,7 @@ function PackMule:draw(Parent)
         GL.Settings:draw("PackMuleIgnores");
     end);
     Parent:AddChild(IgnoredItems);
-    
+
     Overview:drawSpacer(Parent, nil, 10);
 
     local Checkboxes = {

--- a/Interface/Settings/PackMule.lua
+++ b/Interface/Settings/PackMule.lua
@@ -37,7 +37,12 @@ function PackMule:draw(Parent)
         {
             label = "Enable for Group Loot",
             setting = "PackMule.enabledForGroupLoot",
+            description = "Only works if you are group leader or loot assist"
         },
+        {
+            label = "Force Group Loot",
+            description = "Roll on items when not leader or loot assist (useful for RDF spam)",
+            setting = "PackMule.forceRoll",
         {
             label = "Disable for Group Loot when leaving group",
             setting = "PackMule.autoDisableForGroupLoot",

--- a/Interface/Settings/PackMule.lua
+++ b/Interface/Settings/PackMule.lua
@@ -41,7 +41,7 @@ function PackMule:draw(Parent)
         },
         {
             label = "Force Group Loot",
-            description = "Roll on items when not leader or loot assist (useful for RDF spam)",
+            description = "Roll on items when not leader or loot assist (useful for RDF spam); requires Group loot to be enabled to work",
             setting = "PackMule.forceRoll",
         },
         {


### PR DESCRIPTION
starting this PR to add ability to add rolling on group loot when not leader\loot assist. Only rolls according to your configured PackMule rules.

Tested with 7.0.1