### PR TITLE
Add option to export list of rolls

### DIFF
--- a/Classes/Exporter.lua
+++ b/Classes/Exporter.lua
@@ -232,6 +232,7 @@ function Exporter:getLootEntries()
             tinsert(Entries, {
                 timestamp = AwardEntry.timestamp,
                 awardedTo = awardedTo,
+                Rolls = AwardEntry.Rolls,
                 itemID = itemID,
                 OS = AwardEntry.OS and 1 or 0,
                 SR = AwardEntry.SR and 1 or 0,
@@ -277,6 +278,13 @@ function Exporter:transformEntriesToCustomFormat(Entries)
             end
 
             if (ItemDetails) then
+                local rolls = {};
+                for _, roll in pairs(AwardEntry.Rolls) do
+                    if (roll.classification == AwardEntry.winningRollType) then
+                        tinsert(rolls, roll.player .. "[".. roll.amount .."]");
+                    end
+                end
+
                 local Values = {
                     ["@ID"] = AwardEntry.itemID,
                     ["@LINK"] = ItemDetails.link:gsub('\124','\124\124'),
@@ -284,6 +292,7 @@ function Exporter:transformEntriesToCustomFormat(Entries)
                     ["@ILVL"] = ItemDetails.level,
                     ["@QUALITY"] = ItemDetails.quality,
                     ["@WINNER"] = GL:nameFormat{ name = AwardEntry.awardedTo, stripRealm = true },
+                    ["@ROLLS"] = table.concat(rolls, " "),
                     ["@REALM"] = GL:getRealmFromName(AwardEntry.awardedTo),
                     ["@OS"] = GL:toboolean(AwardEntry.OS),
                     ["@SR"] = GL:toboolean(AwardEntry.SR),

--- a/Interface/Settings/ExportingLoot.lua
+++ b/Interface/Settings/ExportingLoot.lua
@@ -170,6 +170,7 @@ function ExportingLoot:draw(Parent)
             "@ILVL",
             "@QUALITY",
             "@WINNER",
+            "@ROLLS",
             "@REALM",
             "@DATE",
             "@OS",


### PR DESCRIPTION
This PR adds `@ROLLS` to custom export options.

This is useful for some wishlist-based systems that give a bonus to people that have seen a loot but didn't win the roll.

The string uses the following format :
`Name[12] Another[31]`

As the name cannot have space, and to not have compatibility issues with the export string template, I choose to use space as the separator. I have added the roll following the name (but maybe it's too much). Only rolls for the same type as the winner are shown in the list.

Your feedback is welcome.