### PR TITLE
Extract roller name/notes formatting into a separate functions

### DIFF
--- a/Classes/RollOff.lua
+++ b/Classes/RollOff.lua
@@ -841,28 +841,27 @@ function RollOff:processRoll(message)
     self:refreshRollsTable();
 end
 
---- Format roller name to display in the roll table
+--- Format roller name to display in the rolls table
 ---
 ---@param playerName string
 ---@param numberOfTimesRolledByPlayer int
 ---@return string
 function RollOff:formatRollerName(playerName, numberOfTimesRolledByPlayer)
-    local rollerName = playerName;
     -- If this isn't the player's first roll for the current item then
     -- we add a number behind the players name like so: PlayerName [#]
     if (numberOfTimesRolledByPlayer > 1) then
-        rollerName = string.format("%s [%s]", playerName, numberOfTimesRolledByPlayer);
+        playerName = ("%s [%s]"):format(playerName, numberOfTimesRolledByPlayer);
     end
 
-    return rollerName
+    return playerName;
 end
 
---- Format roll notes for the roll table
+--- Format roll notes for the rolls table
 ---
 ---@param rollNotes table
 ---@return string
 function RollOff:formatRollNotes(rollNotes)
-    return table.concat(rollNotes, ", ")
+    return table.concat(rollNotes, ", ");
 end
 
 -- Whenever a new roll comes in we need to refresh

--- a/Classes/RollOff.lua
+++ b/Classes/RollOff.lua
@@ -841,6 +841,22 @@ function RollOff:processRoll(message)
     self:refreshRollsTable();
 end
 
+--- Format roller name to display in the roll table
+---
+---@param playerName string
+---@param numberOfTimesRolledByPlayer int
+---@return string
+function RollOff:formatRollerName(playerName, numberOfTimesRolledByPlayer)
+    local rollerName = playerName;
+    -- If this isn't the player's first roll for the current item then
+    -- we add a number behind the players name like so: PlayerName [#]
+    if (numberOfTimesRolledByPlayer > 1) then
+        rollerName = string.format("%s [%s]", playerName, numberOfTimesRolledByPlayer);
+    end
+
+    return rollerName
+end
+
 -- Whenever a new roll comes in we need to refresh
 -- the rolls table to make sure it actually shows up
 function RollOff:refreshRollsTable()
@@ -959,20 +975,13 @@ function RollOff:refreshRollsTable()
             end
         end
 
-        local rollerName = playerName;
-        -- If this isn't the player's first roll for the current item then
-        -- we add a number behind the players name like so: PlayerName [#]
-        if (numberOfTimesRolledByPlayer > 1) then
-            rollerName = string.format("%s [%s]", playerName, numberOfTimesRolledByPlayer);
-        end
-
         local class = Roll.class;
         local plusOnes = GL.PlusOnes:getPlusOnes(playerName);
 
         local Row = {
             cols = {
                 {
-                    value = rollerName,
+                    value = self:formatRollerName(playerName, numberOfTimesRolledByPlayer),
                     color = GL:classRGBAColor(class),
                 },
                 {

--- a/Classes/RollOff.lua
+++ b/Classes/RollOff.lua
@@ -857,6 +857,14 @@ function RollOff:formatRollerName(playerName, numberOfTimesRolledByPlayer)
     return rollerName
 end
 
+--- Format roll notes for the roll table
+---
+---@param rollNotes table
+---@return string
+function RollOff:formatRollNotes(rollNotes)
+    return table.concat(rollNotes, ", ")
+end
+
 -- Whenever a new roll comes in we need to refresh
 -- the rolls table to make sure it actually shows up
 function RollOff:refreshRollsTable()
@@ -997,7 +1005,7 @@ function RollOff:refreshRollsTable()
                     color = GL:classRGBAColor(class),
                 },
                 {
-                    value = table.concat(rollNotes, ", "),
+                    value = self:formatRollNotes(rollNotes),
                     color = GL:classRGBAColor(class),
                 },
                 {


### PR DESCRIPTION
**Motivation**

As discussed in discord, due to various ranks in Guild runs and allowing pugs, having an easier way to organise and discern "Raider" ranks from standard members and pugs when "rolling" out loot would be ideal. At the same time, it's understanable that the feature is too niche to maintain and test by original Gargul devs. 

I will gladly create a separate addon that will display the guild rank next to the name of the player, in the same column, However, to do this, I would need to overwrite the whole `RollOff.refreshRollsTable` function which is undesirable. Especially so given that I only want to change a small portion of it related to roller name formatting.

The idea is to extract the roller name formatting in a separate function that is accessible from `_G.Gargul` namespace. This way, the new addon will only have to ovewrite this one.

**Changes**

- extracts the formatting of the roller name into a separate function 
- extracts the formatting of the roller notes into a separate function 

