### PR TITLE
Update itemClassIDsToIgnore with new values

### DIFF
--- a/Classes/PackMule.lua
+++ b/Classes/PackMule.lua
@@ -20,8 +20,8 @@ GL.PackMule = {
     -- We ignore recipes and questitems by default
     -- since they might not always be tradably
     itemClassIDsToIgnore = {
-        LE_ITEM_CLASS_RECIPE,
-        LE_ITEM_CLASS_QUESTITEM,
+        9,
+        12,
     },
 
     playerIsInHeroicInstance = false,


### PR DESCRIPTION
In TBC Anniversary, it's automatically rolling on Recipes.

> LE_ITEM_CLASS_RECIPE value is: nil

This just isn't getting set, so I changed it back to using IDs. 

> Name: Recipe: Invisibility Potion 
> Class: 9 Recipe 
> SubClass: 6 Alchemy

Needs more testing, but the API returns the ID for the type in TBC Anniversary so I think this will work.

