### PR TITLE
GDKP ledger: show 42 rows and sort zero-cut players last

### DIFF
--- a/Interface/GDKP/LedgerList.lua
+++ b/Interface/GDKP/LedgerList.lua
@@ -36,9 +36,12 @@ GL.Interface.GDKP.LedgerList = {
 local LedgerList = GL.Interface.GDKP.LedgerList;
 
 --[[ CONSTANTS ]]
-local TABLE_ROWS = 40;
+-- 42 rows at 15px tall occupy ~630px, slightly less than the old 40 rows at 16px
+-- (~640px), so a full 40-man roster (plus a couple) fits in the same vertical space
+-- without the table growing taller and clipping off the screen.
+local TABLE_ROWS = 42;
 local DEFAULT_PLAYER_COLUMN_WIDTH = 90;
-local HEIGHT_PER_ROW = 16;
+local HEIGHT_PER_ROW = 15;
 
 local PLAYERS_TABLE_COLUMNS = {
     { name = L["Player"], width = DEFAULT_PLAYER_COLUMN_WIDTH, },
@@ -324,6 +327,14 @@ function LedgerList:refresh()
 
         table.sort(PlayerNames, function (a, b)
             if (a and b) then
+                -- Sort real cuts before zero cuts, alphabetical within each group,
+                -- so zero-cut players are the ones clipped off a too-long screenshot
+                local aHasCut = (Cuts[a] or 0) > 0;
+                local bHasCut = (Cuts[b] or 0) > 0;
+                if (aHasCut ~= bHasCut) then
+                    return aHasCut;
+                end
+
                 return a < b;
             end
 


### PR DESCRIPTION
the ledger screenshot was cut off at the bottom with large raids because the players table only rendered 40 rows. changes:

- show 42 player rows instead of 40 so a full 40-man roster (plus a couple) fits without clipping. this is done by changing the constant for the number of rows. in addition, the row height is reduced from 16 to 15px so the higher row count still occupies the same vertical space (42 * 15 ~= 630px vs the old 40 * 16 = 640px) and does not overflow the window. in testing if this is not done, the content of the window can overflow over the boundaries of the window.
-
- sort players with a real cut before players with a zero cut, keeping each group alphabetical. this is so if the roster still overflows the screenshot, the zero-cut players are the ones clipped off the bottom rather than players who actually raided.

before test: note the manufactured example here with 45 raiders, 4 of which have 0 cut. there are 5 raiders that are getting cut off.
<img width="1295" height="858" alt="Screenshot 2026-06-12 at 9 55 44 PM" src="https://github.com/user-attachments/assets/748ee97f-2068-44a1-a852-e10f52aab9ee" />

after this pr test: we have 42 rows, so all 41 with cuts are shown. all the 0s are pushed to the bottom, as you can see in the 42nd row. there are 3 more cut off here, but they are 0 cut folks.
<img width="1289" height="859" alt="Screenshot 2026-06-12 at 9 54 11 PM" src="https://github.com/user-attachments/assets/a525e504-b8d9-4539-a5aa-785c36b7fa7a" />